### PR TITLE
(feat): Adding support to suppress methods and parameters from a plugin

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,11 +28,11 @@ jobs:
 
     - name: Build
       working-directory: ./src/
-      run: dotnet build --no-restore
+      run: dotnet build --configuration Release --no-restore
 
     - name: Test
       working-directory: ./src/
-      run: dotnet test --no-build -v Normal --logger trx --collect:"XPlat Code Coverage" --results-directory:"TestResults/Coverage/" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByAttribute=GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute
+      run: dotnet test --configuration Release --no-build -v Normal --logger trx --collect:"XPlat Code Coverage" --results-directory:"TestResults/Coverage/" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByAttribute=GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute
 
     - name: Generate Test Report
       uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,7 +52,7 @@ jobs:
         REPORT_PATH: ./src/TestResults/Reports/Summary.json
       run: |
         THRESHOLD=80
-        COVERAGE=$(jq '.summary.methodcoverage' < $REPORT_PATH)
+        COVERAGE=$(jq '.summary.linecoverage' < $REPORT_PATH)
         echo "Coverage: $COVERAGE%"
         if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
           echo "Code coverage ($COVERAGE%) is below the threshold ($THRESHOLD%)"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,56 @@ var kernelBuilder = services.AddKernel();
 kernelBuilder.Plugins.AddFromTypeWithMetadata<TimePlugin>();
 ```
 
+## Suppressing Functions and Parameters
+
+The library now supports suppressing functions and parameters in plugin metadata. This feature allows you to hide specific functions or parameters from the plugin's consumers while maintaining functionality. For parameters, if a default value is provided, it will be used even when the parameter is suppressed.
+
+### Suppressing a Function
+
+To suppress a function, set the `Suppress` property to `true` in the `FunctionMetadata`.
+
+```csharp
+public class CustomMetadataProvider : IPluginMetadataProvider
+{
+    public PluginMetadata? GetPluginMetadata(KernelPlugin plugin) => null;
+
+    public FunctionMetadata GetFunctionMetadata(KernelPlugin plugin, KernelFunctionMetadata metadata) =>
+        plugin.Name == "SamplePlugin" && metadata.Name == "HiddenFunction"
+            ? new FunctionMetadata(metadata.Name) { Suppress = true }
+            : null;
+}
+```
+
+### Suppressing a Parameter
+
+To suppress a parameter, set the `Suppress` property to `true` in the `ParameterMetadata`. If a default value is provided, it will be used.
+
+```csharp
+public class CustomMetadataProvider : IPluginMetadataProvider
+{
+    public PluginMetadata? GetPluginMetadata(KernelPlugin plugin) => null;
+
+    public FunctionMetadata GetFunctionMetadata(KernelPlugin plugin, KernelFunctionMetadata metadata) =>
+        plugin.Name == "SamplePlugin" && metadata.Name == "FunctionWithHiddenParameter"
+            ? new FunctionMetadata(metadata.Name)
+            {
+                Parameters = new List<ParameterMetadata>
+                {
+                    new ParameterMetadata("hiddenParam") { Suppress = true, DefaultValue = "default" }
+                }
+            }
+            : null;
+}
+```
+
+#### Additional Notes on Suppressing Parameters
+
+When a parameter is set to `Suppress`, it must either be optional or have a default value provided. This default value can be specified in the underlying implementation or through the metadata provider.
+
+- **Default Value Precedence**: If a default value is provided through the metadata provider, it takes precedence over the default value specified in the original plugin implementation.
+
+This ensures that suppressed parameters are handled gracefully without causing runtime errors.
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request.

--- a/src/SemanticPluginForge.Core/Models/FunctionMetadata.cs
+++ b/src/SemanticPluginForge.Core/Models/FunctionMetadata.cs
@@ -17,6 +17,11 @@ public class FunctionMetadata(string name)
     public string Name { get; init; } = name;
 
     /// <summary>
+    /// Gets if the function should be suppressed from the plugin.
+    /// </summary>
+    public bool Suppress { get; init; } = false;
+
+    /// <summary>
     /// Gets the description of the function, suitable for use in describing the purpose to a model.
     /// </summary>
     public string? Description { get; init; }

--- a/src/SemanticPluginForge.Core/Models/ParameterMetadata.cs
+++ b/src/SemanticPluginForge.Core/Models/ParameterMetadata.cs
@@ -15,8 +15,21 @@ public class ParameterMetadata(string name) : ParameterMetadataBase
     public string Name { get; private set; } = name;
 
     /// <summary>
+    /// Gets if the parameter should be suppressed from the function.
+    /// </summary>
+    /// <remarks>
+    /// If the parameter is suppressed, but <see cref="DefaultValue"/> is set, the parameter won't be visible
+    /// to LLM to resolve the value, but, the default value will be used.
+    /// </remarks>
+    public bool Suppress { get; init; } = false;
+
+    /// <summary>
     /// Gets the default value of the parameter.
     /// </summary>
+    /// <remarks>
+    /// If it is set and <see cref="Suppress"/> is set to <see langword="true"/>, the parameter won't be visible
+    /// to LLM to resolve the value, but, the default value will be used.
+    /// </remarks>
     public object? DefaultValue { get; init; }
 
     /// <summary>

--- a/src/SemanticPluginForge.Core/PluginBuilder.cs
+++ b/src/SemanticPluginForge.Core/PluginBuilder.cs
@@ -23,25 +23,21 @@ public class PluginBuilder(IPluginMetadataProvider metadataProvider) : IPluginBu
             {
                 pluginAltered = true;
 
-                var method = (Kernel kernel, KernelFunction currentFunction, KernelArguments arguments, CancellationToken cancellationToken) =>
+                if (functionMeta.Suppress)
                 {
-                    return function.InvokeAsync(kernel, arguments, cancellationToken);
-                };
+                    // This function should be suppressed from the plugin.
+                    continue;
+                }
+
+                var method = BuildMethodInvocation(function, functionMeta);
+
+                List<KernelParameterMetadata> parameters = BuildKernelParameters(function, functionMeta);
 
                 var options = new KernelFunctionFromMethodOptions
                 {
                     FunctionName = function.Name,
                     Description = functionMeta.Description ?? function.Metadata.Description,
-                    Parameters = function.Metadata.Parameters.Select(p =>
-                    {
-                        var paramMeta = functionMeta.Parameters?.FirstOrDefault(paramMeta => paramMeta.Name == p.Name);
-                        return paramMeta == null ? p : new KernelParameterMetadata(p)
-                        {
-                            Description = paramMeta.Description ?? p.Description,
-                            IsRequired = paramMeta.IsRequired ?? p.IsRequired,
-                            DefaultValue = paramMeta.DefaultValue ?? p.DefaultValue
-                        };
-                    }),
+                    Parameters = parameters,
                     ReturnParameter = functionMeta.ReturnParameter == null ? function.Metadata.ReturnParameter : new KernelReturnParameterMetadata(function.Metadata.ReturnParameter)
                     {
                         Description = functionMeta.ReturnParameter.Description ?? function.Metadata.Description,
@@ -64,5 +60,62 @@ public class PluginBuilder(IPluginMetadataProvider metadataProvider) : IPluginBu
         }
 
         return plugin;
+    }
+
+    private static List<KernelParameterMetadata> BuildKernelParameters(KernelFunction function, FunctionMetadata functionMeta)
+    {
+        var parameters = new List<KernelParameterMetadata>();
+        foreach (var param in function.Metadata.Parameters)
+        {
+            var paramMeta = functionMeta.Parameters?.FirstOrDefault(p => p.Name == param.Name);
+            if (paramMeta != null)
+            {
+                if (paramMeta.Suppress)
+                {
+                    if (param.IsRequired && paramMeta.DefaultValue == null && param.DefaultValue == null)
+                    {
+                        // This parameter is required and cannot be suppressed without a default value.
+                        // Throw an exception to indicate that the parameter cannot be suppressed.
+                        // This is to ensure that the plugin does not break when the function is called.
+                        // The user should be aware of this and handle it accordingly.
+                        throw new ArgumentException($"Parameter '{param.Name}' is required and cannot be suppressed without a default value.");
+                    }
+
+                    // This parameter should be suppressed from the function.
+                    continue;
+                }
+
+                parameters.Add(new KernelParameterMetadata(param)
+                {
+                    Description = paramMeta.Description ?? param.Description,
+                    IsRequired = paramMeta.IsRequired ?? param.IsRequired,
+                    DefaultValue = paramMeta.DefaultValue ?? param.DefaultValue
+                });
+            }
+            else
+            {
+                parameters.Add(param);
+            }
+        }
+
+        return parameters;
+    }
+
+    private static Func<Kernel, KernelFunction, KernelArguments, CancellationToken, Task<FunctionResult>> BuildMethodInvocation(KernelFunction function, FunctionMetadata functionMeta)
+    {
+        return (Kernel kernel, KernelFunction currentFunction, KernelArguments arguments, CancellationToken cancellationToken) =>
+        {
+            foreach (var param in functionMeta.Parameters ?? Enumerable.Empty<ParameterMetadata>())
+            {
+                var kernelParameterMetadata = function.Metadata.Parameters.FirstOrDefault(p => p.Name == param.Name);
+                if (param.Suppress)
+                {
+                    // Setting suppressed parameters to their default values if available. The default value from the metadata provider has precedence.
+                    arguments[param.Name] = param.DefaultValue ?? kernelParameterMetadata?.DefaultValue;
+                }
+            }
+
+            return function.InvokeAsync(kernel, arguments, cancellationToken);
+        };
     }
 }

--- a/src/SemanticPluginForge.UnitTests/ExtensionMethods.cs
+++ b/src/SemanticPluginForge.UnitTests/ExtensionMethods.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using Microsoft.SemanticKernel;
+using SemanticPluginForge.Core;
+
+namespace SemanticPluginForge.UnitTests;
+
+public static class ExtensionMethods
+{
+    public static void FunctionsMetaShouldBe(this KernelPlugin plugin, List<FunctionMetadata> expectedFunctionsMetadata)
+    {
+        var functionsMetadata = plugin.GetFunctionsMetadata();
+        functionsMetadata.Should().HaveCount(expectedFunctionsMetadata.Count);
+        foreach (var expectedFunctionMetadata in expectedFunctionsMetadata)
+        {
+            var functionMetadata = functionsMetadata.Single(f => f.Name == expectedFunctionMetadata.Name);
+            functionMetadata.Description.Should().Be(expectedFunctionMetadata.Description);
+            functionMetadata.Parameters.Should().HaveCount(expectedFunctionMetadata.Parameters!.Count);
+            foreach (var expectedParameterMetadata in expectedFunctionMetadata.Parameters)
+            {
+                var parameterMetadata = functionMetadata.Parameters.Single(p => p.Name == expectedParameterMetadata.Name);
+                parameterMetadata.Description.Should().Be(expectedParameterMetadata.Description);
+                parameterMetadata.IsRequired.Should().Be(expectedParameterMetadata.IsRequired!.Value);
+                parameterMetadata.DefaultValue.Should().Be(expectedParameterMetadata.DefaultValue);
+            }
+            functionMetadata.ReturnParameter.Description.Should().Be(expectedFunctionMetadata.ReturnParameter?.Description);
+        }
+    }
+}

--- a/src/SemanticPluginForge.UnitTests/PluginBuilderTest.cs
+++ b/src/SemanticPluginForge.UnitTests/PluginBuilderTest.cs
@@ -4,89 +4,348 @@ using Moq;
 
 using SemanticPluginForge.Core;
 
-namespace SemanticPluginForge.UnitTests
+namespace SemanticPluginForge.UnitTests;
+
+public class PluginBuilderTests
 {
-    public class PluginBuilderTests
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldReturnUnalteredPlugin_WhenNoFunctionMetadataExists()
     {
-        [Fact]
-        public void PatchKernelPluginWithMetadata_ShouldReturnUnalteredPlugin_WhenNoFunctionMetadataExists()
+        // Arrange
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns(null as PluginMetadata);
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.IsAny<KernelFunctionMetadata>()))
+            .Returns(null as FunctionMetadata);
+
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var functionsMetadata = result.GetFunctionsMetadata();
+
+        // Assert
+        result.Should().BeSameAs(kernelPlugin);
+        result.Description.Should().Be("Sample plugin for testing.");
+        result.FunctionsMetaShouldBe(GetExpectedFunctionsMetadata());
+    }
+
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenPluginDescriptionExists()
+    {
+        // Arrange
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var functionsMetadata = result.GetFunctionsMetadata();
+
+        // Assert
+        result.Should().NotBeSameAs(kernelPlugin);
+        result.Description.Should().Be("Plugin description altered using patch mechanism.");
+        result.FunctionsMetaShouldBe(GetExpectedFunctionsMetadata());
+    }
+
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenFunctionMetadataExists()
+    {
+        // Arrange
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetCurrentUsername))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) {
+                Description = "Function description altered using patch mechanism.",
+                ReturnParameter = new ReturnParameterMetadata { Description = "The username of the current user." }
+        });
+
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var functionsMetadata = result.GetFunctionsMetadata();
+
+        // Assert
+        result.Should().NotBeSameAs(kernelPlugin);
+        result.Description.Should().Be("Sample plugin for testing.");
+        var expectedFunctionsMetadata = GetExpectedFunctionsMetadata(
+            usernameFunctionDescription: "Function description altered using patch mechanism.",
+            usernameReturnDescription: "The username of the current user."
+        );
+        result.FunctionsMetaShouldBe(expectedFunctionsMetadata);
+    }
+
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenPluginDescriptionAndFunctionMetadataExists()
+    {
+        // Arrange
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetCurrentUsername))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) {
+                Description = "Function description altered using patch mechanism."
+        });
+
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var functionsMetadata = result.GetFunctionsMetadata();
+
+        // Assert
+        result.Should().NotBeSameAs(kernelPlugin);
+        result.Description.Should().Be("Plugin description altered using patch mechanism.");
+        var expectedFunctionsMetadata = GetExpectedFunctionsMetadata(
+            usernameFunctionDescription: "Function description altered using patch mechanism."
+        );
+        result.FunctionsMetaShouldBe(expectedFunctionsMetadata);
+    }
+
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenFunctionIsSuppressed()
+    {
+        // Arrange
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetCurrentUsername))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Suppress = true });
+
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var functionsMetadata = result.GetFunctionsMetadata();
+
+        // Assert
+        result.Should().NotBeSameAs(kernelPlugin);
+        result.Description.Should().Be("Plugin description altered using patch mechanism.");
+        var expectedFunctionsMetadata = GetExpectedFunctionsMetadata();
+        expectedFunctionsMetadata.Remove(expectedFunctionsMetadata.Single(f => f.Name == nameof(SamplePlugin.GetCurrentUsername)));
+        result.FunctionsMetaShouldBe(expectedFunctionsMetadata);
+    }
+
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenParameterIsSuppressed()
+    {
+        // Arrange
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetAllCities))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Parameters = new List<ParameterMetadata> { new ParameterMetadata("filter") { Suppress = true } } });
+
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var functionsMetadata = result.GetFunctionsMetadata();
+
+        // Assert
+        result.Should().NotBeSameAs(kernelPlugin);
+        result.Description.Should().Be("Plugin description altered using patch mechanism.");
+        var expectedFunctionsMetadata = GetExpectedFunctionsMetadata();
+        var expectedFunctionMetadata = expectedFunctionsMetadata.Single(f => f.Name == nameof(SamplePlugin.GetAllCities));
+        expectedFunctionsMetadata.Remove(expectedFunctionMetadata);
+        expectedFunctionsMetadata.Add(new FunctionMetadata(expectedFunctionMetadata.Name)
         {
-            // Arrange
-            var metadataProviderMock = new Mock<IPluginMetadataProvider>();
-            metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns(null as PluginMetadata);
-            metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.IsAny<KernelFunctionMetadata>()))
-                .Returns(null as FunctionMetadata);
+            Description = expectedFunctionMetadata.Description,
+            Parameters = expectedFunctionMetadata.Parameters!.Where(p => p.Name != "filter").ToList(),
+            ReturnParameter = expectedFunctionMetadata.ReturnParameter
+        });
+        result.FunctionsMetaShouldBe(expectedFunctionsMetadata);
+    }
 
-            var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
-            var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldThrowException_WhenAttemptingToSuppressRequiredParameterWithoutDefault()
+    {
+        // 
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetTemperatureByCity))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Parameters = new List<ParameterMetadata> { new ParameterMetadata("name") { Suppress = true } } });
 
-            // Act
-            var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
 
-            // Assert
-            result.Should().BeSameAs(kernelPlugin);
-            result.Description.Should().Be("Sample plugin for testing");
-            result.GetFunctionsMetadata().First().Description.Should().Be("Returns the current username");
-        }
+        // Act/Assert
+        pluginBuilder.Invoking(x => x.PatchKernelPluginWithMetadata(kernelPlugin))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("Parameter 'name' is required and cannot be suppressed without a default value.");
+    }
 
-        [Fact]
-        public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenPluginDescriptionExists()
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenAttemptingToSuppressRequiredParameterWithDefault()
+    {
+        // 
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetTemperatureByCity))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Parameters = new List<ParameterMetadata> { new ParameterMetadata("name") { Suppress = true, DefaultValue = "Amsterdam" } } });
+
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var functionsMetadata = result.GetFunctionsMetadata();
+
+        // Assert
+        result.Should().NotBeSameAs(kernelPlugin);
+        result.Description.Should().Be("Plugin description altered using patch mechanism.");
+        var expectedFunctionsMetadata = GetExpectedFunctionsMetadata();
+        var expectedFunctionMetadata = expectedFunctionsMetadata.Single(f => f.Name == nameof(SamplePlugin.GetTemperatureByCity));
+        expectedFunctionsMetadata.Remove(expectedFunctionMetadata);
+        expectedFunctionsMetadata.Add(new FunctionMetadata(expectedFunctionMetadata.Name)
         {
-            // Arrange
-            var metadataProviderMock = new Mock<IPluginMetadataProvider>();
-            metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+            Description = expectedFunctionMetadata.Description,
+            Parameters = expectedFunctionMetadata.Parameters!.Where(p => p.Name != "name").ToList(),
+            ReturnParameter = expectedFunctionMetadata.ReturnParameter
+        });
+        result.FunctionsMetaShouldBe(expectedFunctionsMetadata);
+    }
 
-            var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
-            var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+    [Fact]
+    public async Task PatchKernelPluginWithMetadata_UsesCorrectDefault_SuppressRequiredParameterWithDefault()
+    {
+        // 
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetTemperatureByCity))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Parameters = new List<ParameterMetadata> { new ParameterMetadata("name") { Suppress = true, DefaultValue = "Amsterdam" } } });
 
-            // Act
-            var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
 
-            // Assert
-            result.Should().NotBeSameAs(kernelPlugin);
-            result.Description.Should().Be("Plugin description altered using patch mechanism.");
-            result.GetFunctionsMetadata().First().Description.Should().Be("Returns the current username");
-        }
+        // Act
+        var patchedPlugin = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var f = patchedPlugin[nameof(SamplePlugin.GetTemperatureByCity)];
+        var result = await f.InvokeAsync(new Kernel());
 
-        [Fact]
-        public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenFunctionMetadataExists()
+        // Assert
+        result.GetValue<string>().Should().Be("Amsterdam temperature is 20 degrees celsius");
+        var functionsMetadata = patchedPlugin.GetFunctionsMetadata();
+        var expectedFunctionsMetadata = GetExpectedFunctionsMetadata();
+        var expectedFunctionMetadata = expectedFunctionsMetadata.Single(f => f.Name == nameof(SamplePlugin.GetTemperatureByCity));
+        expectedFunctionsMetadata.Remove(expectedFunctionMetadata);
+        expectedFunctionsMetadata.Add(new FunctionMetadata(expectedFunctionMetadata.Name)
         {
-            // Arrange
-            var metadataProviderMock = new Mock<IPluginMetadataProvider>();
-            metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.IsAny<KernelFunctionMetadata>()))
-                .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Description = "Function description altered using patch mechanism." });
+            Description = expectedFunctionMetadata.Description,
+            Parameters = expectedFunctionMetadata.Parameters!.Where(p => p.Name != "name").ToList(),
+            ReturnParameter = expectedFunctionMetadata.ReturnParameter
+        });
+        patchedPlugin.FunctionsMetaShouldBe(expectedFunctionsMetadata);
+    }
 
-            var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
-            var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+    [Fact]
+    public async Task PatchKernelPluginWithMetadata_UsesCorrectDefault_SuppressOptionalParameterWithDefault()
+    {
+        // 
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetTemperatureByCity))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Parameters = new List<ParameterMetadata> { new ParameterMetadata("unit") { Suppress = true } } });
 
-            // Act
-            var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
 
-            // Assert
-            result.Should().NotBeSameAs(kernelPlugin);
-            result.Description.Should().Be("Sample plugin for testing");
-            result.GetFunctionsMetadata().First().Description.Should().Be("Function description altered using patch mechanism.");
-        }
+        // Act
+        var patchedPlugin = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var f = patchedPlugin[nameof(SamplePlugin.GetTemperatureByCity)];
+        var result = await f.InvokeAsync(new Kernel(), new KernelArguments { { "name", "Utrecht" } });
 
-        [Fact]
-        public void PatchKernelPluginWithMetadata_ShouldReturnAlteredPlugin_WhenPluginDescriptionAndFunctionMetadataExists()
-        {
-            // Arrange
-            var metadataProviderMock = new Mock<IPluginMetadataProvider>();
-            metadataProviderMock.Setup(p => p.GetPluginMetadata(It.IsAny<KernelPlugin>())).Returns<KernelPlugin>(p => new PluginMetadata { Description = "Plugin description altered using patch mechanism." });
-            metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.IsAny<KernelFunctionMetadata>()))
-                .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Description = "Function description altered using patch mechanism." });
+        // Assert
+        result.GetValue<string>().Should().Be("Utrecht temperature is 20 degrees celsius");
+    }
 
-            var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
-            var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
+    [Fact]
+    public async Task PatchKernelPluginWithMetadata_UsesCorrectDefault_SuppressOptionalParameterWithDefaultOverride()
+    {
+        // 
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        metadataProviderMock.Setup(p => p.GetFunctionMetadata(It.IsAny<KernelPlugin>(), It.Is<KernelFunctionMetadata>(func => func.Name == nameof(SamplePlugin.GetTemperatureByCity))))
+            .Returns<KernelPlugin, KernelFunctionMetadata>((p, m) => new FunctionMetadata(m.Name) { Parameters = new List<ParameterMetadata> { new ParameterMetadata("unit") { Suppress = true, DefaultValue = "fahrenheit" } } });
 
-            // Act
-            var result = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var kernelPlugin = KernelPluginFactory.CreateFromObject(new SamplePlugin());
 
-            // Assert
-            result.Should().NotBeSameAs(kernelPlugin);
-            result.Description.Should().Be("Plugin description altered using patch mechanism.");
-            result.GetFunctionsMetadata().First().Description.Should().Be("Function description altered using patch mechanism.");
-        }
+        // Act
+        var patchedPlugin = pluginBuilder.PatchKernelPluginWithMetadata(kernelPlugin);
+        var f = patchedPlugin[nameof(SamplePlugin.GetTemperatureByCity)];
+        var result = await f.InvokeAsync(new Kernel(), new KernelArguments { { "name", "Rotterdam" } });
+
+        // Assert
+        result.GetValue<string>().Should().Be("Rotterdam temperature is 20 degrees fahrenheit");
+    }
+
+    [Fact]
+    public void PatchKernelPluginWithMetadata_ShouldHandleEmptyPlugin()
+    {
+        // Arrange
+        var metadataProviderMock = new Mock<IPluginMetadataProvider>();
+        var pluginBuilder = new PluginBuilder(metadataProviderMock.Object);
+        var emptyPlugin = KernelPluginFactory.CreateFromFunctions("EmptyPlugin", "", new List<KernelFunction>());
+
+        // Act
+        var result = pluginBuilder.PatchKernelPluginWithMetadata(emptyPlugin);
+
+        // Assert
+        result.Should().BeSameAs(emptyPlugin);
+        result.FunctionCount.Should().Be(0);
+    }
+
+    private List<FunctionMetadata> GetExpectedFunctionsMetadata(
+        string usernameFunctionDescription = "Returns the current username.",
+        string usernameReturnDescription = "",
+        string citiesFunctionDescription = "Returns all the cities based on the filter provided.",
+        string citiesReturnDescription = ""
+    )
+    {
+        return 
+        [
+            new FunctionMetadata(nameof(SamplePlugin.GetCurrentUsername))
+            {
+                Description = usernameFunctionDescription,
+                Parameters = [],
+                ReturnParameter = new ReturnParameterMetadata { Description = usernameReturnDescription }
+            },
+            new FunctionMetadata(nameof(SamplePlugin.GetAllCities))
+            {
+                Description = citiesFunctionDescription,
+                Parameters = 
+                [
+                    new ParameterMetadata("filter")
+                    {
+                        Description = "Optional filter parameter which can be used to get a subset of cities",
+                        IsRequired = false,
+                        DefaultValue = null
+                    }
+                ],
+                ReturnParameter = new ReturnParameterMetadata { Description = citiesReturnDescription }
+            },
+            new FunctionMetadata(nameof(SamplePlugin.GetTemperatureByCity))
+            {
+                Description = "Returns the current temperature of the city.",
+                Parameters = 
+                [
+                    new ParameterMetadata("name")
+                    {
+                        Description = "The name of the city",
+                        IsRequired = true,
+                        DefaultValue = null
+                    },
+                    new ParameterMetadata("unit")
+                    {
+                        Description = "The temperature unit, default is celsius",
+                        IsRequired = false,
+                        DefaultValue = "celsius"
+                    }
+                ],
+                ReturnParameter = new ReturnParameterMetadata { Description = "" }
+            }
+        ];
     }
 }

--- a/src/SemanticPluginForge.UnitTests/SamplePlugin.cs
+++ b/src/SemanticPluginForge.UnitTests/SamplePlugin.cs
@@ -3,9 +3,31 @@ using Microsoft.SemanticKernel;
 
 namespace SemanticPluginForge.UnitTests;
 
-[Description("Sample plugin for testing")]
+[Description("Sample plugin for testing.")]
 public class SamplePlugin
 {
-    [KernelFunction, Description("Returns the current username")]
-    public string GetUsername() => "my_user";
+    [KernelFunction, Description("Returns the current username.")]
+    public string GetCurrentUsername() => "my_user";
+
+    [KernelFunction, Description("Returns all the cities based on the filter provided.")]
+    public List<string> GetAllCities([Description("Optional filter parameter which can be used to get a subset of cities")]string? filter = null)
+    {
+        var users = new List<string> { "amsterdam", "rotterdam", "london", "paris", "berlin" };
+
+        if (filter != null)
+        {
+            users = users.Where(u => u.Contains(filter)).ToList();
+        }
+
+        return users;
+    }
+
+    [KernelFunction, Description("Returns the current temperature of the city.")]
+    public string GetTemperatureByCity(
+        [Description("The name of the city")]string name,
+        [Description("The temperature unit, default is celsius")]string unit = "celsius"
+    )
+    {
+        return $"{name} temperature is 20 degrees {unit}";
+    }
 }


### PR DESCRIPTION
# Summary

This pull request introduces a new feature that allows the suppression of methods and parameters from a plugin. This enhancement provides greater flexibility and control over plugin behavior.