### PR TITLE
Adding support to override function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,15 @@ kernelBuilder.Plugins.AddFromClrTypeWithMetadata<ShortDate>("ShortDatePlugin");
 
 ## Samples
 
-Explore the [`samples`](./samples/) directory for practical examples of using `SemanticPluginForge` in different scenarios. Each subdirectory contains a specific use case with its own `README.md` and source code.
+Explore the [`samples`](./samples/) directory for practical examples of using `SemanticPluginForge` in different scenarios. Each sample includes comprehensive documentation, setup instructions, and focuses on specific framework concepts.
 
-- **DefaultValue**: Demonstrates how to suppress a parameter and use default values in plugin metadata, suppressing also ensures that there is no chance of the value being ever resolved from the context. This also showcases how the description of the parameter is overridden to retrieve the location of the user from the context.
-- **UseClrType**: Shows how to use CLR types and objects as plugins.
+### Available Samples
+
+- **[DefaultValue](./samples/DefaultValue/)**: Demonstrates advanced parameter handling including suppression, default values, and context-aware metadata. Shows how to override parameter descriptions and ensure parameters are never resolved from context when suppressed.
+
+- **[UseClrType](./samples/UseClrType/)**: Shows how to use existing .NET classes as Semantic Kernel plugins without requiring `KernelFunction` attributes. Demonstrates both type-based and object-based registration approaches.
+
+- **[AzureAiSearchPlugin](./samples/AzureAiSearchPlugin/)**: Comprehensive example showing how to create multiple instances of the same plugin class with different metadata configurations for various data sources. Uses mocked data for learning without external dependencies.
 
 Navigate to the [`samples`](./samples/) folder to get started with these examples.
 

--- a/src/SemanticPluginForge.Core/Models/FunctionMetadata.cs
+++ b/src/SemanticPluginForge.Core/Models/FunctionMetadata.cs
@@ -13,8 +13,17 @@ public class FunctionMetadata(string name)
 {
     /// <summary>
     /// Gets the name of the function.
+    /// This name should match the name of the function in the plugin.
+    /// It is used to identify the function in the plugin and to call it.
     /// </summary>
     public string Name { get; init; } = name;
+
+    /// <summary>
+    /// Gets the name of the function to override in the plugin.
+    /// This is used to specify a different name for the function in the plugin than the one
+    /// defined in the actual plugin.
+    /// </summary>
+    public string? OverrideFunctionName { get; init; }
 
     /// <summary>
     /// Gets if the function should be suppressed from the plugin.

--- a/src/SemanticPluginForge.Core/PluginBuilder.cs
+++ b/src/SemanticPluginForge.Core/PluginBuilder.cs
@@ -35,7 +35,7 @@ public class PluginBuilder(IPluginMetadataProvider metadataProvider) : IPluginBu
 
                 var options = new KernelFunctionFromMethodOptions
                 {
-                    FunctionName = functionMeta.Name,
+                    FunctionName = functionMeta.OverrideFunctionName ?? functionMeta.Name,
                     Description = functionMeta.Description ?? function.Metadata.Description,
                     Parameters = parameters,
                     ReturnParameter = functionMeta.ReturnParameter == null ? function.Metadata.ReturnParameter : new KernelReturnParameterMetadata(function.Metadata.ReturnParameter)


### PR DESCRIPTION
Adds support for #12 

New optional property `OverrideFunctionName` added to `FunctionMetadata`. Setting this overrides the function name.