### PR TITLE
bug: Handle function name duplicates when using TAP

### DIFF
--- a/samples/FunctionLogger.cs
+++ b/samples/FunctionLogger.cs
@@ -5,9 +5,11 @@ public class FunctionLogger : IAutoFunctionInvocationFilter
     public async Task OnAutoFunctionInvocationAsync(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
     {
         var arguments = context.Arguments?.Select(a => $"{a.Key}={a.Value}") ?? Enumerable.Empty<string>();
-        Console.WriteLine($"Plugin: {context.Function.PluginName}, Function: {context.Function.Name}({string.Join(',', arguments)})");
-        
+        Console.WriteLine($"[Invoking] Plugin: {context.Function.PluginName}, Function: {context.Function.Name}({string.Join(',', arguments)})");
+
         await next(context);
+        
+        Console.WriteLine($"[Invoked] Plugin: {context.Function.PluginName}, Function: {context.Function.Name}({string.Join(',', arguments)}) with result: {context.Result}");
     }
 
     public async Task OnFunctionInvocationAsync(FunctionInvocationContext context, Func<FunctionInvocationContext, Task> next)

--- a/samples/UseClrType/CustomMetadataProvider.cs
+++ b/samples/UseClrType/CustomMetadataProvider.cs
@@ -3,15 +3,109 @@ using SemanticPluginForge.Core;
 
 public class CustomMetadataProvider : IPluginMetadataProvider
 {
-  public PluginMetadata? GetPluginMetadata(KernelPlugin plugin) =>
-    plugin.Name == "ShortDatePlugin" ? new PluginMetadata
+    public PluginMetadata? GetPluginMetadata(KernelPlugin plugin)
     {
-      Description = "This plugin returns date and time information."
-    } : null;
+        return plugin.Name switch
+        {
+            "DateTimeWrapper" => new PluginMetadata
+            {
+                Description = "This plugin returns date and time information."
+            },
+            "RandomPlugin" => new PluginMetadata
+            {
+                Description = "This plugin generates random numbers and values."
+            },
+            "Queue" => new PluginMetadata
+            {
+                Description = "This plugin interacts with Azure Storage Queues."
+            },
+            _ => null,
+        };
+    }
 
-  public FunctionMetadata? GetFunctionMetadata(KernelPlugin plugin, KernelFunctionMetadata metadata) =>
-    plugin.Name == "ShortDatePlugin" && metadata.Name == "ToShortDateString" ? new FunctionMetadata(metadata.Name)
+    public FunctionMetadata? GetFunctionMetadata(KernelPlugin plugin, KernelFunctionMetadata metadata)
     {
-      Description = "Returns the date in short format."
-    } : null;
+        return plugin.Name switch
+        {
+            "DateTimeWrapper" => metadata.Name switch
+            {
+                "ToShortDateString" => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Returns the current date in short format (MM/dd/yyyy)."
+                },
+                "ToLongDateString" => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Returns the current date in long format (day of week, month day, year)."
+                },
+                "CurrentTime" => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Returns the current time in HH:MM:SS format."
+                },
+                "CurrentDateTime" => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Returns the current date and time in long format."
+                },
+                "GetDayOfWeek" => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Returns the name of the day of the week for the current date."
+                },
+                _ => null
+            },
+            "RandomPlugin" => metadata.Name switch
+            {
+                "Next" when metadata.Parameters.Count == 0 => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Returns a non-negative random integer."
+                },
+                "Next" when metadata.Parameters.Count == 1 => new FunctionMetadata(metadata.Name)
+                {
+                    OverrideFunctionName = "NextWithUpperBound",
+                    Description = "Returns a random integer within a specified range.",
+                    Parameters = [
+                        new ParameterMetadata("maxValue") { Description = "The exclusive upper bound of the random number returned." }
+                    ]
+                },
+                "Next" when metadata.Parameters.Count == 2 => new FunctionMetadata(metadata.Name)
+                {
+                    OverrideFunctionName = "NextWithRange",
+                    Description = "Returns a random integer within a specified range.",
+                    Parameters = [
+                        new ParameterMetadata("minValue") { Description = "The inclusive lower bound of the random number returned." },
+                        new ParameterMetadata("maxValue") { Description = "The exclusive upper bound of the random number returned." }
+                    ]
+                },
+                _ => null
+            },
+            "Queue" => metadata.Name switch
+            {
+                "ReceiveMessages" when metadata.Parameters.Count == 2 => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Retrieves messages from the Azure Storage Queue.",
+                    Parameters = new List<ParameterMetadata>
+                    {
+                        new ParameterMetadata("maxMessages") { Description = "The maximum number of messages to retrieve.", DefaultValue = "5", IsRequired = false },
+                        new ParameterMetadata("visibilityTimeout") { Description = "Specifies the new visibility timeout value, in seconds, relative to server time", DefaultValue = "60", IsRequired = false },
+                    },
+                },
+                "PeekMessages" when metadata.Parameters.Count == 1 => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Peeks at messages in the Azure Storage Queue without removing them.",
+                    Parameters = new List<ParameterMetadata>
+                    {
+                        new ParameterMetadata("maxMessages") { Description = "The maximum number of messages to peek.", DefaultValue = "5", IsRequired = false },
+                    },
+                },
+                "SendMessage" when metadata.Parameters.Count == 1 => new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Sends a message to the Azure Storage Queue.",
+                    Parameters = new List<ParameterMetadata>
+                    {
+                        new ParameterMetadata("messageText") { Description = "The message to send." },
+                    },
+                },
+                _ => null
+            },
+            _ => null,
+        };
+    }
 }

--- a/samples/UseClrType/DateTimeWrapper.cs
+++ b/samples/UseClrType/DateTimeWrapper.cs
@@ -1,0 +1,27 @@
+public class DateTimeWrapper
+{
+    public string ToShortDateString()
+    {
+        return DateTime.Now.ToShortDateString();
+    }
+
+    public string ToLongDateString()
+    {
+        return DateTime.Now.ToLongDateString();
+    }
+
+    public string CurrentTime()
+    {
+        return DateTime.Now.ToString("T");
+    }
+
+    public string CurrentDateTime()
+    {
+        return DateTime.Now.ToString("F");
+    }
+    
+    public string GetDayOfWeek()
+    {
+        return DateTime.Now.DayOfWeek.ToString();
+    }
+}

--- a/samples/UseClrType/ShortDate.cs
+++ b/samples/UseClrType/ShortDate.cs
@@ -1,7 +1,0 @@
-public class ShortDate
-{
-  public string ToShortDateString()
-  {
-    return DateTime.Now.ToShortDateString();
-  }
-}

--- a/samples/UseClrType/UseClrType.csproj
+++ b/samples/UseClrType/UseClrType.csproj
@@ -13,6 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
+     <Compile Include="..\FunctionLogger.cs" Link="FunctionLogger.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.22.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.48.0" />
   </ItemGroup>

--- a/src/SemanticPluginForge.Core/IFunctionBuilder.cs
+++ b/src/SemanticPluginForge.Core/IFunctionBuilder.cs
@@ -1,0 +1,17 @@
+using Microsoft.SemanticKernel;
+
+namespace SemanticPluginForge.Core;
+
+/// <summary>
+/// Interface for a function builder.
+/// </summary>
+public interface IFunctionBuilder
+{
+    /// <summary>
+    /// Patch a KernelFunction object.
+    /// </summary>
+    /// <param name="plugin">The plugin which contains the function.</param>
+    /// <param name="function">The function which should be patched.</param>
+    /// <returns>Returns null if the function should be suppressed, <paramref name="function"/> if the function should not be patched otherwise the patched function.</returns>
+    KernelFunction? PatchKernelFunctionWithMetadata(KernelPlugin plugin, KernelFunction function);
+}

--- a/src/SemanticPluginForge.Core/IPluginBuilder.cs
+++ b/src/SemanticPluginForge.Core/IPluginBuilder.cs
@@ -8,9 +8,9 @@ namespace SemanticPluginForge.Core;
 public interface IPluginBuilder
 {
     /// <summary>
-    /// Patch a KernelPlugin object with external metadata.
+    /// Patch a KernelPlugin object.
     /// </summary>
-    /// <param name="plugin">The plugin which should be patched with external metadata.</param>
+    /// <param name="plugin">The plugin which should be patched.</param>
     /// <returns>Returns the patched plugin instance.</returns>
     KernelPlugin PatchKernelPluginWithMetadata(KernelPlugin plugin);
 }

--- a/src/SemanticPluginForge.UnitTests/AsyncMethodsPlugin.cs
+++ b/src/SemanticPluginForge.UnitTests/AsyncMethodsPlugin.cs
@@ -1,0 +1,57 @@
+using Microsoft.SemanticKernel;
+using SemanticPluginForge.Core;
+
+namespace SemanticPluginForge.UnitTests
+{
+    public partial class KernelPluginForgeTests
+    {
+        private class AsyncMethodsPlugin
+        {
+            // Normal method
+            public string GetData() 
+            {
+                return "Some data";
+            }
+            
+            // Normal method with CancellationToken
+            public string GetData(CancellationToken cancellationToken = default) 
+            {
+                return "Some data";
+            }
+            
+            // Async version of the same method
+            public Task<string> GetDataAsync() 
+            {
+                return Task.FromResult("Some data");
+            }
+            
+            // Async version of the same method with CancellationToken
+            public Task<string> GetDataAsync(CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult("Some data");
+            }
+        }
+
+        private class AsyncMethodsMetadataProvider : IPluginMetadataProvider
+        {
+            public PluginMetadata? GetPluginMetadata(KernelPlugin plugin) =>
+                plugin.Name == "AsyncMethodsPlugin" ? new PluginMetadata
+                {
+                    Description = "This plugin tests async method filtering."
+                } : null;
+
+            public FunctionMetadata? GetFunctionMetadata(KernelPlugin plugin, KernelFunctionMetadata metadata)
+            {
+                if (plugin.Name == "AsyncMethodsPlugin" && metadata.Name == "GetData")
+                {
+                    return new FunctionMetadata(metadata.Name)
+                    {
+                        Description = "Function GetData for testing async filtering."
+                    };
+                }
+                
+                return null;
+            }
+        }
+    }
+}

--- a/src/SemanticPluginForge.UnitTests/GenericMethodsPlugin.cs
+++ b/src/SemanticPluginForge.UnitTests/GenericMethodsPlugin.cs
@@ -1,0 +1,83 @@
+using Microsoft.SemanticKernel;
+using SemanticPluginForge.Core;
+
+namespace SemanticPluginForge.UnitTests
+{
+    public partial class KernelPluginForgeTests
+    {
+        private class GenericMethodsPlugin<T>
+        {
+            // Closed generic method
+            public T? ClosedGenericMethod()
+            {
+                return default;
+            }
+
+            // Open generic method with one type parameter
+            public string OpenGenericMethodWithParameter<TParam>(TParam param)
+            {
+                return $"Parameter type: {typeof(TParam).Name}, Value: {param}";
+            }
+
+            // Open generic method with multiple type parameters
+            public string OpenGenericMethodWithMultipleParameters<TParam1, TParam2>(TParam1 param1, TParam2 param2)
+            {
+                return $"Parameter types: {typeof(TParam1).Name}, {typeof(TParam2).Name}, Values: {param1}, {param2}";
+            }
+
+            // Open generic method with generic return type
+            public TReturn? OpenGenericMethodWithReturnType<TReturn>()
+            {
+                return default;
+            }
+            
+            // Open generic method with generic return type and parameters
+            public TReturn? OpenGenericMethodWithReturnTypeAndParameters<TParam, TReturn>(TParam param)
+            {
+                return default;
+            }
+        }
+
+        private class GenericMethodsPluginMetadataProvider : IPluginMetadataProvider
+        {
+            public PluginMetadata? GetPluginMetadata(KernelPlugin plugin) =>
+                plugin.Name == "GenericMethodsPlugin" ? new PluginMetadata
+                {
+                    Description = "This plugin tests generic method filtering."
+                } : null;
+
+            public FunctionMetadata? GetFunctionMetadata(KernelPlugin plugin, KernelFunctionMetadata metadata)
+            {
+                if (plugin.Name != "GenericMethodsPlugin")
+                {
+                    return null;
+                }
+
+                return metadata.Name switch
+                {
+                    "ClosedGenericMethod" => new FunctionMetadata(metadata.Name)
+                    {
+                        Description = "Closed generic method that returns a default value of type T."
+                    },
+                    "OpenGenericMethodWithParameter" => new FunctionMetadata(metadata.Name)
+                    {
+                        Description = "Open generic method with one type parameter."
+                    },
+                    "OpenGenericMethodWithMultipleParameters" => new FunctionMetadata(metadata.Name)
+                    {
+                        Description = "Open generic method with multiple type parameters."
+                    },
+                    "OpenGenericMethodWithReturnType" => new FunctionMetadata(metadata.Name)
+                    {
+                        Description = "Open generic method with a generic return type."
+                    },
+                    "OpenGenericMethodWithReturnTypeAndParameters" => new FunctionMetadata(metadata.Name)
+                    {
+                        Description = "Open generic method with a generic return type and parameters."
+                    },
+                    _ => null,
+                };
+            }
+        }
+    }
+}

--- a/src/SemanticPluginForge.UnitTests/KernelPluginForgeTests.cs
+++ b/src/SemanticPluginForge.UnitTests/KernelPluginForgeTests.cs
@@ -1,6 +1,5 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.SemanticKernel;
 using SemanticPluginForge.Core;
 
 namespace SemanticPluginForge.UnitTests
@@ -112,6 +111,48 @@ namespace SemanticPluginForge.UnitTests
                     Parameters = [],
                     ReturnParameter = new ReturnParameterMetadata { Description = string.Empty }
                 }
+            ]);
+        }
+
+        [Fact]
+        public void CreateFromClrObjectWithMetadata_FiltersOpenGenericMethods()
+        {
+            // Arrange
+            var serviceProvider = new ServiceCollection()
+                .AddSingleton<IPluginMetadataProvider, GenericMethodsPluginMetadataProvider>()
+                .BuildServiceProvider();
+
+            var pluginName = "GenericMethodsPlugin";
+
+            // Act
+            var plugin = KernelPluginForge.CreateFromClrTypeWithMetadata<GenericMethodsPlugin<string>>(serviceProvider, pluginName);
+
+            // Assert
+            plugin.Should().NotBeNull();
+            plugin.Name.Should().Be(pluginName);
+            plugin.FunctionsMetaShouldBe([
+                new FunctionMetadata("ClosedGenericMethod")
+                {
+                    Description = "Closed generic method that returns a default value of type T.",
+                    Parameters = [],
+                    ReturnParameter = new ReturnParameterMetadata { Description = string.Empty }
+                },
+                // new FunctionMetadata("OpenGenericMethodWithParameter")
+                // {
+                //     Description = "Open generic method with one type parameter."
+                // },
+                // new FunctionMetadata("OpenGenericMethodWithMultipleParameters")
+                // {
+                //     Description = "Open generic method with multiple type parameters."
+                // },
+                // new FunctionMetadata("OpenGenericMethodWithReturnType")
+                // {
+                //     Description = "Open generic method with a generic return type."
+                // },
+                // new FunctionMetadata("OpenGenericMethodWithReturnTypeAndParameters")
+                // {
+                //     Description = "Open generic method with a generic return type and parameters."
+                // }
             ]);
         }
     }

--- a/src/SemanticPluginForge.UnitTests/StubPluginWithoutAttribute.cs
+++ b/src/SemanticPluginForge.UnitTests/StubPluginWithoutAttribute.cs
@@ -1,0 +1,31 @@
+using Microsoft.SemanticKernel;
+using SemanticPluginForge.Core;
+
+namespace SemanticPluginForge.UnitTests
+{
+    public partial class KernelPluginForgeTests
+    {
+        private class StubPluginWithoutAttribute
+        {
+            public string ToShortDateString()
+            {
+                return DateTime.Now.ToShortDateString();
+            }
+        }
+
+        private class StubPluginMetadataProvider : IPluginMetadataProvider
+        {
+            public PluginMetadata? GetPluginMetadata(KernelPlugin plugin) =>
+                plugin.Name == "DateTimePlugin" ? new PluginMetadata
+                {
+                    Description = "This plugin returns date and time information."
+                } : null;
+
+            public FunctionMetadata? GetFunctionMetadata(KernelPlugin plugin, KernelFunctionMetadata metadata) =>
+                plugin.Name == "DateTimePlugin" && metadata.Name == "ToShortDateString" ? new FunctionMetadata(metadata.Name)
+                {
+                    Description = "Returns the date in short format."
+                } : null;
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses the issue where function name duplicates were not handled when using the Task-based Asynchronous Pattern (TAP) in CLR type plugins. This happens in two specific scenarios:

1. When a type contains both an async method and a non-async method where the only difference is the 'Async' suffix (e.g., GetData() and GetDataAsync()). Semantic Kernel removes the 'Async' suffix during registration, causing a duplicate method error.
2. When methods differ only by having a CancellationToken parameter (e.g., GetData() and GetData(CancellationToken)). Semantic Kernel removes the CancellationToken parameter in the KernelFunctionMetadata, again resulting in duplicate method errors.

The plugin builder now filters out these duplicates by normalizing the functions by removing the cancellation token parameter and async suffix then choosing the one with the CancellationToken parameter if available or the one with async suffix in the order.

Also sample have been updated to use Random, which showcases how to handle function overload and azure queue client sdk where the tap function name duplicate happens.

Closes #16 
